### PR TITLE
All events can be sent to the webhook notifier, not only the deployment event

### DIFF
--- a/_scalingo_api/notifiers.md
+++ b/_scalingo_api/notifiers.md
@@ -76,8 +76,6 @@ Notifications are app events sent to a custom HTTP endpoint. You can refer to
 our ['Events' documentation](/events) to
 know the notification JSON format.
 
-At the moment only `deployment` events are sent.
-
 ||| col |||
 
 Example of a deployment notification:

--- a/_scalingo_api/notifiers.md
+++ b/_scalingo_api/notifiers.md
@@ -94,10 +94,18 @@ Example of a deployment notification:
   "type": "deployment",
   "type_data": {
     "deployment_id" : "5343eccd646aa3012a140230",
+    "deployment_type": "deployment",
     "pusher": "johndoe",
+    "stack": "scalingo-18",
+    "last_commits": {
+      "commits": [],
+      "remaining": 0
+    },
     "git_ref" : "0123456789abcdef",
+    "git_ref_url": "https://github.com/johndoe/appname/commit/0123456789abcdef",
     "status": "success",
-    "duration": 40
+    "duration": 40,
+    "finished_at": "2020-04-16T14:55:05.338+00:00"
   }
 }
 ```


### PR DESCRIPTION
Close #88 

There are events missing from the list displayed in the documentation [here](https://developers.scalingo.com/events), like new SCM events https://github.com/Scalingo/developers-documentation/issues/89.