### PR TITLE
docs: remove https from API URL values

### DIFF
--- a/_database_api/index.md
+++ b/_database_api/index.md
@@ -20,8 +20,8 @@ Scalingo being available on multiple regions, the Database API hostname depends
 on the region your database is hosted on. It's designated by `DB_API_URL`
 in this documentation and must be replaced with one of the following value:
 
-- 3DS Outscale Paris: https://db-api.osc-fr1.scalingo.com
-- 3DS Outscale Paris SecNumCloud: https://db-api.osc-secnum-fr1.scalingo.com
+- 3DS Outscale Paris: db-api.osc-fr1.scalingo.com
+- 3DS Outscale Paris SecNumCloud: db-api.osc-secnum-fr1.scalingo.com
 
 --- row ---
 

--- a/_database_api/index.md
+++ b/_database_api/index.md
@@ -20,8 +20,8 @@ Scalingo being available on multiple regions, the Database API hostname depends
 on the region your database is hosted on. It's designated by `DB_API_URL`
 in this documentation and must be replaced with one of the following value:
 
-- 3DS Outscale Paris: db-api.osc-fr1.scalingo.com
-- 3DS Outscale Paris SecNumCloud: db-api.osc-secnum-fr1.scalingo.com
+- 3DS Outscale Paris: `db-api.osc-fr1.scalingo.com`
+- 3DS Outscale Paris SecNumCloud: `db-api.osc-secnum-fr1.scalingo.com`
 
 --- row ---
 

--- a/_scalingo_api/index.md
+++ b/_scalingo_api/index.md
@@ -50,8 +50,8 @@ Scalingo being available on multiple regions, the API endpoint depends on the
 region your application is hosted on. It's designated by `SCALINGO_API_URL` in
 this documentation and must be replaced with one of the following value:
 
-- 3DS Outscale Paris: api.osc-fr1.scalingo.com
-- 3DS Outscale Paris SecNumCloud: api.osc-secnum-fr1.scalingo.com
+- 3DS Outscale Paris: `api.osc-fr1.scalingo.com`
+- 3DS Outscale Paris SecNumCloud: `api.osc-secnum-fr1.scalingo.com`
 
 ## HTTP Verbs
 

--- a/_scalingo_api/index.md
+++ b/_scalingo_api/index.md
@@ -50,8 +50,8 @@ Scalingo being available on multiple regions, the API endpoint depends on the
 region your application is hosted on. It's designated by `SCALINGO_API_URL` in
 this documentation and must be replaced with one of the following value:
 
-- 3DS Outscale Paris: https://api.osc-fr1.scalingo.com
-- 3DS Outscale Paris SecNumCloud: https://api.osc-secnum-fr1.scalingo.com
+- 3DS Outscale Paris: api.osc-fr1.scalingo.com
+- 3DS Outscale Paris SecNumCloud: api.osc-secnum-fr1.scalingo.com
 
 ## HTTP Verbs
 


### PR DESCRIPTION
All examples already contains the scheme part. E.g.

```
GET https://$SCALINGO_API_URL/v1/apps/[:app]/variables
```