### PR TITLE
Remove empty table for delete_project event

### DIFF
--- a/_scalingo_api/events.md
+++ b/_scalingo_api/events.md
@@ -1984,10 +1984,6 @@ Example object:
 _When:_ A project has been deleted
 `type=delete_project`
 
-{:.table}
-| field   | type    | description                                     |
-| ------- | ------- | ----------------------------------------------- |
-
 ||| col |||
 
 Example object:


### PR DESCRIPTION
The `delete_project` attributes table is broken: 
![Capture d’écran 2025-07-08 à 16 29 26](https://github.com/user-attachments/assets/82d61af0-070f-4695-81d5-935193830e25)

Result after this PR changes:
![Capture d’écran 2025-07-08 à 16 37 23](https://github.com/user-attachments/assets/a43ca79f-e644-4fd0-82b5-627a5063399f)
