### PR TITLE
fix: Data access consent endpoints documentation

### DIFF
--- a/_scalingo_api/data_access_consents.md
+++ b/_scalingo_api/data_access_consents.md
@@ -56,7 +56,7 @@ Example request
 
 ```shell
 curl -H 'Accept: application/json' -H 'Content-Type: application/json' -u ":$AUTH_TOKEN" \
-  -X POST https://$SCALINGO_API_URL/v1/apps/example-app/data_access_consents -d \
+  -X POST https://$SCALINGO_API_URL/v1/apps/example-app/data_access_consent -d \
   '{
     "data_access_consent": {
       "databases_until": "2022-07-06T00:00:00.000+00:00",


### PR DESCRIPTION
Data access consent resource descriptions were not ISO with our API. 
- Updated payloads & descriptions
- Removes GET endpoint, which does not exists